### PR TITLE
Two minor fixes

### DIFF
--- a/das_watchdog.c
+++ b/das_watchdog.c
@@ -27,6 +27,7 @@
 #include <stdarg.h>
 
 #include <sys/types.h>
+#include <sys/wait.h>
 
 #include <pthread.h>
 #include <pwd.h>
@@ -608,6 +609,9 @@ int main(int argc,char **argv){
       pll_delete(pll);
     }
     if(testing==1) break;
+
+    // Clean up any child processes.
+    waitpid(-1, NULL, WNOHANG);
   }
   
   return 0;

--- a/test_rt.c
+++ b/test_rt.c
@@ -9,7 +9,9 @@
 
 int main() {
 	struct sched_param params;
-	int done = 0;
+	// "done" is volatile to prevent the compiler from optimising the
+	// time-wasting loops below into nothing.
+	volatile int done = 0;
 	struct timeval tv;
 	time_t startsec;
 	unsigned long int loops;


### PR DESCRIPTION
Make test_rt work when compiled with clang, and avoid leaving zombies in das_watchdog.
